### PR TITLE
Fix unnecessary effect reruns

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -119,7 +119,7 @@ const SideLinks = ({
         }, revealDelay);
 
         return () => clearTimeout(timeout);
-    });
+    }, [revealDelay]);
 
     // * Link List Items
     const sideLinkItems = linkList.map((linkItem, index) => {
@@ -355,7 +355,7 @@ const SkillsSection = ({
             if (localToolsTitle) observer.unobserve(localToolsTitle);
             if (localToolsContainer) observer.unobserve(localToolsContainer);
         };
-    });
+    }, []);
 
     const displayFormatter = (item: IconDetails) => {
         const { description, iconComponent } = item;


### PR DESCRIPTION
## Summary
- prevent SideLinks timeout from recreating on every render
- only attach intersection observers once

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f745ebe48322a1d0c8696c92f54c